### PR TITLE
Merge per-player killCount fixes

### DIFF
--- a/scripts/commandHandler.lua
+++ b/scripts/commandHandler.lua
@@ -731,7 +731,7 @@ function commandHandler.ProcessCommand(pid, cmd)
             end
         end
 
-    elseif cmd[1] == "resetkills" and moderator and config.shareKill == true then
+    elseif cmd[1] == "resetkills" and moderator and config.shareKills == true then
 
         -- Set all currently recorded kills to 0 for connected players
         for refId, killCount in pairs(WorldInstance.data.kills) do
@@ -742,7 +742,7 @@ function commandHandler.ProcessCommand(pid, cmd)
         WorldInstance:LoadKills(pid, true)
         tes3mp.SendMessage(pid, "All the kill counts for creatures and NPCs have been reset.\n", true)
         
-    elseif cmd[1] == "resetkills" and config.shareKill == false then
+    elseif cmd[1] == "resetkills" and config.shareKills == false then
 	
 		if Players[pid].data.kills == nil then
 			Players[pid].data.kills = {}

--- a/scripts/commandHandler.lua
+++ b/scripts/commandHandler.lua
@@ -731,7 +731,7 @@ function commandHandler.ProcessCommand(pid, cmd)
             end
         end
 
-    elseif cmd[1] == "resetkills" and moderator then
+    elseif cmd[1] == "resetkills" and moderator and config.shareKill == true then
 
         -- Set all currently recorded kills to 0 for connected players
         for refId, killCount in pairs(WorldInstance.data.kills) do

--- a/scripts/commandHandler.lua
+++ b/scripts/commandHandler.lua
@@ -741,7 +741,21 @@ function commandHandler.ProcessCommand(pid, cmd)
         WorldInstance:QuicksaveToDrive()
         WorldInstance:LoadKills(pid, true)
         tes3mp.SendMessage(pid, "All the kill counts for creatures and NPCs have been reset.\n", true)
+        
+    elseif cmd[1] == "resetkills" and config.shareKill == false then
+	
+		if Players[pid].data.kills == nil then
+			Players[pid].data.kills = {}
+		end
+        -- Set all currently recorded kills to 0 for players
+        for refId, killCount in pairs(Players[pid].data.kills) do
+            Players[pid].data.kills[refId] = 0
+        end
 
+        Players[pid]:QuicksaveToDrive()
+        Players[pid]:LoadKills(pid, false)
+        tes3mp.SendMessage(pid, "All the kill counts for creatures and NPCs have been reset.\n", false)
+        
     elseif cmd[1] == "suicide" then
         if config.allowSuicideCommand == true then
             tes3mp.SetHealthCurrent(pid, 0)

--- a/scripts/config.lua
+++ b/scripts/config.lua
@@ -115,6 +115,9 @@ config.shareMapExploration = false
 -- Whether ingame videos should be played for other players when triggered by one player
 config.shareVideos = true
 
+-- Whether mobs and npcs in the game should be shared for all players when killed
+config.shareKill = true
+
 -- Which clientside script records should be blanked out so they are not run
 -- Note: By default, the original character generation scripts are included
 --       because they're not suitable for multiplayer

--- a/scripts/config.lua
+++ b/scripts/config.lua
@@ -116,7 +116,7 @@ config.shareMapExploration = false
 config.shareVideos = true
 
 -- Whether mobs and npcs in the game should be shared for all players when killed
-config.shareKill = true
+config.shareKills = true
 
 -- Which clientside script records should be blanked out so they are not run
 -- Note: By default, the original character generation scripts are included

--- a/scripts/eventHandler.lua
+++ b/scripts/eventHandler.lua
@@ -226,7 +226,7 @@ eventHandler.InitializeDefaultHandlers = function()
 				
 				tes3mp.AddKill(actor.refId, Players[pid].data.kills[actor.refId])
 				
-				for alliedName, slot in pairs(Players[pid].data.alliedPlayers) do	
+				for _, alliedName in ipairs(self.data.alliedPlayers) do	
 				
 					local alliedPid = logicHandler.GetPlayerByName(alliedName).pid
 					
@@ -254,7 +254,7 @@ eventHandler.InitializeDefaultHandlers = function()
 			
 			for targetIndex, actor in pairs(actors) do
 			
-				for targetName, slot in pairs(sendKills[targetIndex].playersName) do
+				for _, targetName in pairs(sendKills[targetIndex].playersName) do
 				
 					local targetPid = logicHandler.GetPlayerByName(targetName).pid
 					

--- a/scripts/eventHandler.lua
+++ b/scripts/eventHandler.lua
@@ -202,7 +202,7 @@ eventHandler.InitializeDefaultHandlers = function()
 			
 			tes3mp.SendWorldKillCount(pid, true)
 			
-		elseif config.shareKill == false then
+		else
 		
 			if Players[pid].data.kills == nil then
 				Players[pid].data.kills = {}

--- a/scripts/eventHandler.lua
+++ b/scripts/eventHandler.lua
@@ -398,7 +398,7 @@ eventHandler.InitializeDefaultHandlers = function()
 						sendKills[uniqueIndex] = {timestamp = os.time(), playersName = {}}	
 					else
 						if os.time() - sendKills[uniqueIndex].timestamp >= 600 then
-							sendKills[uniqueIndex] = nil
+							sendKills[uniqueIndex] = {timestamp = os.time(), playersName = {}}
 						else
 							sendKills[uniqueIndex].timestamp = os.time()
 						end

--- a/scripts/eventHandler.lua
+++ b/scripts/eventHandler.lua
@@ -254,7 +254,7 @@ eventHandler.InitializeDefaultHandlers = function()
 			
 			for targetIndex, actor in pairs(actors) do
 			
-				for _, targetName in pairs(sendKills[targetIndex].playersName) do
+				for _, targetName in ipairs(sendKills[targetIndex].playersName) do
 				
 					local targetPid = logicHandler.GetPlayerByName(targetName).pid
 					

--- a/scripts/eventHandler.lua
+++ b/scripts/eventHandler.lua
@@ -227,24 +227,28 @@ eventHandler.InitializeDefaultHandlers = function()
 				tes3mp.AddKill(actor.refId, Players[pid].data.kills[actor.refId])
 				
 				for _, alliedName in ipairs(Players[pid].data.alliedPlayers) do	
-				
-					local alliedPid = logicHandler.GetPlayerByName(alliedName).pid
+
+					if logicHandler.GetPlayerByName(alliedName) then
 					
-					if Players[alliedPid] ~= nil and Players[alliedPid]:IsLoggedIn() then	
-					
-						if Players[alliedPid].data.kills == nil then
-							Players[alliedPid].data.kills = {}
+						local alliedPid = logicHandler.GetPlayerByName(alliedName).pid
+						
+						if Players[alliedPid] ~= nil and Players[alliedPid]:IsLoggedIn() then	
+						
+							if Players[alliedPid].data.kills == nil then
+								Players[alliedPid].data.kills = {}
+							end
+							
+							if Players[alliedPid].data.kills[actor.refId] == nil then
+								Players[alliedPid].data.kills[actor.refId] = 0
+							end
+							
+							Players[alliedPid].data.kills[actor.refId] = Players[alliedPid].data.kills[actor.refId] + 1
+							Players[alliedPid]:QuicksaveToDrive()
+							tableHelper.insertValueIfMissing(sendKills[uniqueIndex].playersName, string.lower(Players[alliedPid].accountName))
+							
 						end
 						
-						if Players[alliedPid].data.kills[actor.refId] == nil then
-							Players[alliedPid].data.kills[actor.refId] = 0
-						end
-						
-						Players[alliedPid].data.kills[actor.refId] = Players[alliedPid].data.kills[actor.refId] + 1
-						Players[alliedPid]:QuicksaveToDrive()
-						tableHelper.insertValueIfMissing(sendKills[uniqueIndex].playersName, string.lower(Players[alliedPid].accountName))
-						
-					end	
+					end
 					
 				end
 

--- a/scripts/eventHandler.lua
+++ b/scripts/eventHandler.lua
@@ -186,7 +186,7 @@ eventHandler.InitializeDefaultHandlers = function()
 
         tes3mp.ClearKillChanges()
 		
-		if config.shareKill == true then
+		if config.shareKills == true then
 		
 			for uniqueIndex, actor in pairs(actors) do
 				if WorldInstance.data.kills[actor.refId] == nil then

--- a/scripts/eventHandler.lua
+++ b/scripts/eventHandler.lua
@@ -189,7 +189,23 @@ eventHandler.InitializeDefaultHandlers = function()
         tes3mp.ClearKillChanges()
 		
 		if config.shareKills == true then
-		
+
+			for uniqueIndex, actor in pairs(actors) do
+				if WorldInstance.data.kills[actor.refId] == nil then
+					WorldInstance.data.kills[actor.refId] = 0
+				end
+
+				WorldInstance.data.kills[actor.refId] = WorldInstance.data.kills[actor.refId] + 1
+				WorldInstance:QuicksaveToDrive()
+				tes3mp.AddKill(actor.refId, WorldInstance.data.kills[actor.refId])
+
+				table.insert(cell.unusableContainerUniqueIndexes, uniqueIndex)
+			end
+
+			tes3mp.SendWorldKillCount(pid, true)
+
+		else
+			
 			if Players[pid].data.kills == nil then
 				Players[pid].data.kills = {}
 			end

--- a/scripts/eventHandler.lua
+++ b/scripts/eventHandler.lua
@@ -185,20 +185,44 @@ eventHandler.InitializeDefaultHandlers = function()
         local cell = LoadedCells[cellDescription]
 
         tes3mp.ClearKillChanges()
+		
+		if config.shareKill == true then
+		
+			for uniqueIndex, actor in pairs(actors) do
+				if WorldInstance.data.kills[actor.refId] == nil then
+					WorldInstance.data.kills[actor.refId] = 0
+				end
 
-        for uniqueIndex, actor in pairs(actors) do
-            if WorldInstance.data.kills[actor.refId] == nil then
-                WorldInstance.data.kills[actor.refId] = 0
-            end
+				WorldInstance.data.kills[actor.refId] = WorldInstance.data.kills[actor.refId] + 1
+				WorldInstance:QuicksaveToDrive()
+				tes3mp.AddKill(actor.refId, WorldInstance.data.kills[actor.refId])
 
-            WorldInstance.data.kills[actor.refId] = WorldInstance.data.kills[actor.refId] + 1
-            WorldInstance:QuicksaveToDrive()
-            tes3mp.AddKill(actor.refId, WorldInstance.data.kills[actor.refId])
+				table.insert(cell.unusableContainerUniqueIndexes, uniqueIndex)
+			end
+			
+			tes3mp.SendWorldKillCount(pid, true)
+			
+		elseif config.shareKill == false then
+		
+			if Players[pid].data.kills == nil then
+				Players[pid].data.kills = {}
+			end
+			
+			for uniqueIndex, actor in pairs(actors) do
+				if Players[pid].data.kills[actor.refId] == nil then
+					Players[pid].data.kills[actor.refId] = 0
+				end
 
-            table.insert(cell.unusableContainerUniqueIndexes, uniqueIndex)
-        end
+				Players[pid].data.kills[actor.refId] = Players[pid].data.kills[actor.refId] + 1
+				Players[pid]:QuicksaveToDrive()
+				tes3mp.AddKill(actor.refId, Players[pid].data.kills[actor.refId])
 
-        tes3mp.SendWorldKillCount(pid, true)
+				table.insert(cell.unusableContainerUniqueIndexes, uniqueIndex)
+			end		
+			
+			tes3mp.SendWorldKillCount(pid, false)
+			
+		end
 
         cell:RequestContainers(pid, tableHelper.getArrayFromIndexes(actors))
     end)

--- a/scripts/eventHandler.lua
+++ b/scripts/eventHandler.lua
@@ -226,7 +226,7 @@ eventHandler.InitializeDefaultHandlers = function()
 				
 				tes3mp.AddKill(actor.refId, Players[pid].data.kills[actor.refId])
 				
-				for _, alliedName in ipairs(self.data.alliedPlayers) do	
+				for _, alliedName in ipairs(Players[pid].data.alliedPlayers) do	
 				
 					local alliedPid = logicHandler.GetPlayerByName(alliedName).pid
 					

--- a/scripts/player/base.lua
+++ b/scripts/player/base.lua
@@ -284,7 +284,11 @@ function BasePlayer:FinishLogin()
             self:LoadReputation()
         end
 
-        WorldInstance:LoadKills(self.pid)
+		if config.shareKill == true then
+			WorldInstance:LoadKills(self.pid)
+		else
+			self:LoadKill(self.pid, false)
+		end	
 
         self:LoadSpecialStates()
 
@@ -376,7 +380,11 @@ function BasePlayer:EndCharGen()
         WorldInstance:LoadTopics(self.pid)
     end
 
-    WorldInstance:LoadKills(self.pid)
+	if config.shareKill == true then
+		WorldInstance:LoadKills(self.pid)
+	else
+		self:LoadKill(self.pid, false)
+	end	
 
     if spawnUsed ~= nil and spawnUsed.cellDescription ~= nil then
         tes3mp.SetCell(self.pid, spawnUsed.cellDescription)

--- a/scripts/player/base.lua
+++ b/scripts/player/base.lua
@@ -1485,6 +1485,21 @@ function BasePlayer:SaveClientScriptGlobal(variables)
     stateHelper:SaveClientScriptGlobal(self, variables)
 end
 
+function BasePlayer:LoadKill(pid, forEveryone)
+    
+    if self.data.kills == nil then
+        self.data.kills = {}
+    end    
+    
+    tes3mp.ClearKillChanges()
+    
+    for refId, killCount in pairs(self.data.kills) do
+        tes3mp.AddKill(refId, killCount)
+    end
+
+    tes3mp.SendWorldKillCount(pid, forEveryone)
+end
+
 function BasePlayer:LoadDestinationOverrides(pid)
     stateHelper:LoadDestinationOverrides(self.pid, self)
 end

--- a/scripts/player/base.lua
+++ b/scripts/player/base.lua
@@ -284,10 +284,10 @@ function BasePlayer:FinishLogin()
             self:LoadReputation()
         end
 
-		if config.shareKill == true then
+		if config.shareKills == true then
 			WorldInstance:LoadKills(self.pid)
 		else
-			self:LoadKill(self.pid, false)
+			self:LoadKills(self.pid, false)
 		end	
 
         self:LoadSpecialStates()
@@ -380,10 +380,10 @@ function BasePlayer:EndCharGen()
         WorldInstance:LoadTopics(self.pid)
     end
 
-	if config.shareKill == true then
+	if config.shareKills == true then
 		WorldInstance:LoadKills(self.pid)
 	else
-		self:LoadKill(self.pid, false)
+		self:LoadKills(self.pid, false)
 	end	
 
     if spawnUsed ~= nil and spawnUsed.cellDescription ~= nil then
@@ -1493,7 +1493,7 @@ function BasePlayer:SaveClientScriptGlobal(variables)
     stateHelper:SaveClientScriptGlobal(self, variables)
 end
 
-function BasePlayer:LoadKill(pid, forEveryone)
+function BasePlayer:LoadKills(pid, forEveryone)
     
     if self.data.kills == nil then
         self.data.kills = {}


### PR DESCRIPTION
Adds per-player killCount handling, which can be disabled via config.lua. Also includes a command to reset killcounts for all players.