### PR TITLE
Generated record enchantment fix

### DIFF
--- a/scripts/commandHandler.lua
+++ b/scripts/commandHandler.lua
@@ -1311,6 +1311,20 @@ function commandHandler.CreateRecord(pid, cmd)
                 "following required settings: " .. tableHelper.concatenateArrayValues(missingSettings, 1, ", ") .. "\n")
             return
         end
+    else
+        if logicHandler.IsGeneratedRecord(storedTable.baseId) then
+            local baseRecordType = logicHandler.GetRecordTypeByRecordId(storedTable.baseId)
+
+            if baseRecordType and RecordStores[baseRecordType].data.generatedRecords[storedTable.baseId] then
+                local baseGeneratedRecord = RecordStores[baseRecordType].data.generatedRecords[storedTable.baseId]
+
+                storedTable.baseId = nil
+                
+                for k, v in pairs(baseGeneratedRecord) do
+                    storedTable[k] = storedTable[k] or v
+                end
+            end
+        end
     end
 
     if inputType == "enchantment" and (storedTable.effects == nil or tableHelper.isEmpty(storedTable.effects)) then

--- a/scripts/config.lua
+++ b/scripts/config.lua
@@ -338,6 +338,9 @@ config.recordStoreLoadOrder = {
 -- The types of records that can be enchanted and therefore have links to enchantment records
 config.enchantableRecordTypes = { "armor", "book", "clothing", "weapon" }
 
+-- The types of records that can have links to body part records
+config.bodyPartRecordTypes = { "armor", "clothing" }
+
 -- The types of records that can be stored by players and therefore have links to players,
 -- listed in the order in which they should be loaded
 config.carriableRecordTypes = { "spell", "potion", "armor", "book", "clothing", "weapon", "ingredient",

--- a/scripts/eventHandler.lua
+++ b/scripts/eventHandler.lua
@@ -1747,10 +1747,9 @@ eventHandler.OnRecordDynamic = function(pid)
                 -- Special handling when using a generated record as baseId
                 if record.baseId and logicHandler.IsGeneratedRecord(record.baseId) then
                     local baseGeneratedRecord = recordStore.data.generatedRecords[record.baseId]
+                    record.baseId = nil
                     for k, v in pairs(baseGeneratedRecord) do
-                        if record[k] == nil or k == "baseId" then
-                            record[k] = v
-                        end
+                        record[k] = record[k] or v
                     end
                 end
 

--- a/scripts/eventHandler.lua
+++ b/scripts/eventHandler.lua
@@ -1744,6 +1744,16 @@ eventHandler.OnRecordDynamic = function(pid)
                     recordId = recordStore:GenerateRecordId()
                 end
 
+                -- Special handling when using a generated record as baseId
+                if record.baseId and logicHandler.IsGeneratedRecord(record.baseId) then
+                    local baseGeneratedRecord = recordStore.data.generatedRecords[record.baseId]
+                    for k, v in pairs(baseGeneratedRecord) do
+                        if record[k] == nil or k == "baseId" then
+                            record[k] = v
+                        end
+                    end
+                end
+
                 if storeType == "enchantment" then
                     -- We need to store this enchantment's original client-generated id
                     -- on this player so we can match it with its server-generated correct

--- a/scripts/recordstore/base.lua
+++ b/scripts/recordstore/base.lua
@@ -112,6 +112,14 @@ function BaseRecordStore:HasLinks(recordId)
                 return true
             end
         end
+    -- Do the same for body parts
+    elseif self.storeType == "bodypart" then
+        for _, bodyPartType in pairs(config.bodyPartRecordTypes) do
+            if recordLinks[recordId].records ~= nil and recordLinks[recordId].records[bodyPartType] ~= nil and not
+                tableHelper.isEmpty(recordLinks[recordId].records[bodyPartType]) then
+                return true
+            end
+        end
     end
 
     return false

--- a/scripts/serverCore.lua
+++ b/scripts/serverCore.lua
@@ -166,9 +166,9 @@ do
             end
             customEventHooks.triggerHandlers("OnGameHour", eventStatus, {})
         end
-    end
 
-    tes3mp.RestartTimer(updateTimerId, time.seconds(1))
+        tes3mp.RestartTimer(updateTimerId, time.seconds(1))
+    end
 end
 
 function OnServerInit()


### PR DESCRIPTION
Enchanting a generated record will cause that record to be eventually erased from the server's memory since it is no longer in the world, causing the baseId of the enchanted version to refer to an object that no longer exists. 

This fixes that bug by ensuring that a record will never retain a generated baseId when it is created.