### PR TITLE
Urm fixes

### DIFF
--- a/scripts/config.lua
+++ b/scripts/config.lua
@@ -360,7 +360,8 @@ config.validRecordSettings = {
     bodypart = { "baseId", "id", "subtype", "part", "model", "race", "vampireState", "flags" },
     book = { "baseId", "id", "name", "model", "icon", "script", "enchantmentId", "enchantmentCharge",
         "text", "weight", "value", "scrollState", "skillId" },
-    cell = { "baseId", "id" },
+    cell = { "baseId", "id", "noSleep", "hasAmbient", "ambient", "sunlight", "hasWater",
+             "waterLevel", "quasiEx", "region" },
     clothing = { "baseId", "id", "name", "model", "icon", "script", "enchantmentId", "enchantmentCharge",
         "subtype", "weight", "value" },
     container = { "baseId", "id", "name", "model", "script", "weight", "flags" },
@@ -423,23 +424,23 @@ config.requiredRecordSettings = {
 -- The record type settings that are mutually exclusive with each other and remove each other when one of
 -- them is set
 config.mutuallyExclusiveRecordSettings = {
-    gamesetting = { "intVar", "floatVar", "stringVar" }
+    gamesetting = { "intVar", "floatVar", "stringVar" , "fog", "sunlight", "ambient"}
 }
 
 -- The record type settings whose input should be converted to numerical values when using /storerecord
 config.numericalRecordSettings = { "subtype", "charge", "cost", "value", "weight", "quality", "uses",
     "time", "radius", "health", "armorRating", "speed", "reach", "scale", "part", "bloodType", "level",
     "magicka", "fatigue", "soulValue", "aiFight", "aiFlee", "aiAlarm", "aiServices", "autoCalc", "gender",
-    "flags", "enchantmentCharge", "intVar", "floatVar" }
+    "flags", "enchantmentCharge", "intVar", "floatVar" , "waterLevel" }
 
 -- The record type settings whose input should be converted to booleans when using /storerecord
-config.booleanRecordSettings = { "scrollState", "keyState", "vampireState" }
+config.booleanRecordSettings = { "scrollState", "keyState", "vampireState" , "hasWater", "hasAmbient", "noSleep", "quiasiEx"}
 
 -- The record type settings whose input should be converted to tables with a min and a max numerical value
 config.minMaxRecordSettings = { "damageChop", "damageSlash", "damageThrust" }
 
 -- The record type settings whose input should be converted to tables with 3 color values
-config.rgbRecordSettings = { "color" }
+config.rgbRecordSettings = { "color" , "sunlight", "ambient"}
 
 -- The types of object and actor packets stored in cell data
 config.cellPacketTypes = { "delete", "place", "spawn", "lock", "trap", "scale", "state", "miscellaneous",

--- a/scripts/packetBuilder.lua
+++ b/scripts/packetBuilder.lua
@@ -349,6 +349,8 @@ packetBuilder.AddCellRecord = function(id, record)
     if record.fog ~= nil then
         tes3mp.SetRecordFog(record.fog.red, record.fog.green, record.fog.blue, record.fog.density)
     end
+    if record.hasWater ~= nil then tes3mp.SetRecordHasWater(record.hasWater) end
+    if record.waterLevel ~= nil then tes3mp.SetRecordWaterLevel(record.waterLevel) end
 
     tes3mp.AddRecord()
 end

--- a/scripts/packetBuilder.lua
+++ b/scripts/packetBuilder.lua
@@ -339,6 +339,16 @@ packetBuilder.AddCellRecord = function(id, record)
 
     tes3mp.SetRecordName(id)
     if record.baseId ~= nil then tes3mp.SetRecordBaseId(record.baseId) end
+    if record.hasAmbient ~= nil then tes3mp.SetRecordHasAmbient(record.hasAmbient) end
+    if record.ambient ~= nil then
+        tes3mp.SetRecordAmbientColor(record.ambient.red, record.ambient.green, record.ambient.blue)
+    end
+    if record.sunlight ~= nil then
+        tes3mp.SetRecordSunlightColor(record.sunlight.red, record.sunlight.green, record.sunlight.blue)
+    end
+    if record.fog ~= nil then
+        tes3mp.SetRecordFog(record.fog.red, record.fog.green, record.fog.blue, record.fog.density)
+    end
 
     tes3mp.AddRecord()
 end

--- a/scripts/packetBuilder.lua
+++ b/scripts/packetBuilder.lua
@@ -351,6 +351,9 @@ packetBuilder.AddCellRecord = function(id, record)
     end
     if record.hasWater ~= nil then tes3mp.SetRecordHasWater(record.hasWater) end
     if record.waterLevel ~= nil then tes3mp.SetRecordWaterLevel(record.waterLevel) end
+    if record.noSleep ~= nil then tes3mp.SetRecordNoSleep(record.noSleep) end
+    if record.quasiEx ~= nil then tes3mp.SetRecordQuasiEx(record.quasiEx) end
+    if record.region ~= nil then tes3mp.SetRecordRegion(record.region) end
 
     tes3mp.AddRecord()
 end


### PR DESCRIPTION
Adds packetBuilder handling for the new lighting/cell functionality within the server.

In order to test these fixes, download the CI artifact for https://github.com/DreamWeave-MP/Dreamweave/pull/27 or build the urm-fixes branch of the core along with the corresponding one in coreScripts.

This example script can be used to test some of the functionality.

```cellMethods = {}

cellMethods.createCell = function(pid, cmd)
  local cellName

  if not cmd[2] then
    cellName = "Balmora, Caius Cosades' House"
  else
    cellName = cmd[2]
  end

  cellMethods.push(pid, cellName, cellTable)

end

cellMethods.push = function (pid, cellName)
	tes3mp.LogAppend(enumerations.log.WARN, "Attempting to push cell: " .. cellName)

	tes3mp.ClearRecords()

	tes3mp.SetRecordType(enumerations.recordType["CELL"])

  local cellTable = {
    region = "sheogorad",
    quasiEx = true,
    fog = {
      red = 0,
      blue = 255,
      green = 0,
      density  = 25.55443,
    },
    hasWater = true,
    waterLevel = 255.255
  }

  RecordStores["cell"].data.permanentRecords[cellName .. " but blue"] = cellTable

  RecordStores["cell"]:QuicksaveToDrive()

  packetBuilder.AddCellRecord(cellName .. " but blue", cellTable)

	tes3mp.SendRecordDynamic(pid, true, false)

end

customCommandHooks.registerCommand("blue", cellMethods.createCell)

return cellMethods
```