### PR TITLE
Feat(records): Also support changing fog values for dynamic cells in …

### DIFF
--- a/scripts/commandHandler.lua
+++ b/scripts/commandHandler.lua
@@ -1217,6 +1217,7 @@ function commandHandler.StoreRecord(pid, cmd)
                 local redValue = tonumber(cmd[4])
                 local greenValue = tonumber(cmd[5])
                 local blueValue = tonumber(cmd[6])
+                local densityValue = tonumber (cmd[7])
 
                 if type(redValue) == "number" and type(greenValue) == "number" and type(blueValue) == "number" and
                     redValue > -1 and redValue < 256 and greenValue > -1 and greenValue < 256 and
@@ -1227,6 +1228,15 @@ function commandHandler.StoreRecord(pid, cmd)
                         inputSetting .. "\n")
                     return
                 end
+
+                if densityValue and type(densityValue) == "number" and densityValue > -1 and densityValue < 256 then
+                  storedTable[inputSetting].density = densityValue
+                else
+                  Players[pid]:Message("Please use three valid numerical values between 0 and 255 as the input for " ..
+                                       inputSetting .. "\n")
+                  return
+                end
+
             elseif tableHelper.containsValue(config.booleanRecordSettings, inputSetting) then
                 if inputValue == "true" or inputValue == "on" or tonumber(inputValue) == 1 then
                     storedTable[inputSetting] = true

--- a/scripts/config.lua
+++ b/scripts/config.lua
@@ -361,7 +361,7 @@ config.validRecordSettings = {
     book = { "baseId", "id", "name", "model", "icon", "script", "enchantmentId", "enchantmentCharge",
         "text", "weight", "value", "scrollState", "skillId" },
     cell = { "baseId", "id", "noSleep", "hasAmbient", "ambient", "sunlight", "hasWater",
-             "waterLevel", "quasiEx", "region" },
+             "waterLevel", "quasiEx", "region", "fog" },
     clothing = { "baseId", "id", "name", "model", "icon", "script", "enchantmentId", "enchantmentCharge",
         "subtype", "weight", "value" },
     container = { "baseId", "id", "name", "model", "script", "weight", "flags" },
@@ -440,7 +440,8 @@ config.booleanRecordSettings = { "scrollState", "keyState", "vampireState" , "ha
 config.minMaxRecordSettings = { "damageChop", "damageSlash", "damageThrust" }
 
 -- The record type settings whose input should be converted to tables with 3 color values
-config.rgbRecordSettings = { "color" , "sunlight", "ambient"}
+-- NOTE: Fog is a special case as it actually is a table with 4 values.
+config.rgbRecordSettings = { "color" , "sunlight", "ambient", "fog"}
 
 -- The types of object and actor packets stored in cell data
 config.cellPacketTypes = { "delete", "place", "spawn", "lock", "trap", "scale", "state", "miscellaneous",


### PR DESCRIPTION
…coreScripts

just finishing up https://github.com/DreamWeave-MP/Dreamweave/issues/33

Something interesting happens when actually creating a cell with the fog field set, as the values expected by the script are between 1 and 255, but density is supposed to be a float value between zero and one. As a result the fog is very bright and dense.

Doesn't appear to be a problem that can be resolved outside of the client at this time, so I think this merge is in an acceptable place for now.