### PR TITLE
Fix(vectors): Proposed resolution to DW #19 , which replaces length operator  overrides with length metamethods

### DIFF
--- a/scripts/vectors.lua
+++ b/scripts/vectors.lua
@@ -7,6 +7,14 @@ function vec3:__call(x, y, z)
     return setmetatable({x=x or 0,y=y or 0,z=z or 0}, getmetatable(self))
 end
 
+function vec3:length()
+    return math.sqrt(self.x^2 + self.y^2 + self.z^2)
+end
+
+function vec3:length2()
+  return self.x^2 + self.y^2 + self.z^2
+end
+
 function vec3.__add(a, b)
     return vec3(a.x + b.x, a.y + b.y, a.z + b.z)
 end
@@ -16,7 +24,7 @@ function vec3.__sub(a, b)
 end
 
 function vec3.__mul(a, b)
-    if type(a) == 'number' then 
+    if type(a) == 'number' then
         return vec3(a * b.x, a * b.y, a * b.z)
     elseif type(b) == 'number' then
         return vec3(a.x * b, a.y * b, a.z*b)
@@ -26,11 +34,6 @@ end
 
 function vec3.__div(a, b)
     return vec3(a.x/b, a.y/b, a.z/b)
-end
-
--- Needs to be changed to __len once Lua 5.2 is supported completely
-function vec3.__unm(a)
-    return math.sqrt(a.x^2 + a.y^2 + a.z^2)
 end
 
 function vec3.__eq(a, b)

--- a/scripts/vectors.lua
+++ b/scripts/vectors.lua
@@ -11,8 +11,9 @@ function vec3:length()
     return math.sqrt(self.x^2 + self.y^2 + self.z^2)
 end
 
-function vec3:length2()
-  return self.x^2 + self.y^2 + self.z^2
+function vec3.__pow(a, b)
+  if type(b) ~= 'number' then return end
+  return vec3(a.x^b, a.y^b, a.z^b) 
 end
 
 function vec3.__add(a, b)


### PR DESCRIPTION
Tracking [DW#19](https://github.com/DreamWeave-MP/Dreamweave/issues/19)

This merge request is a proposed resolution to the above issue, in lieu of [DW#67](https://github.com/DreamWeave-MP/Dreamweave/pull/67)'s attempt to actually build LuaJIT ourselves.

I think handling this as a Lua problem is cleaner, and puts us *that* much closer in line with OpenMW's behavior. The discussion is still open, but I don't believe there is a better way to go here *unless* OpenMW indicates they are willing to retroactively enable the 52 extensions for us in LuaJIT builds they provide.