### PR TITLE
feat(server): Implement chat color filtering for player submitted messages

### DIFF
--- a/scripts/config.lua
+++ b/scripts/config.lua
@@ -118,6 +118,10 @@ config.shareVideos = true
 -- Whether mobs and npcs in the game should be shared for all players when killed
 config.shareKills = true
 
+-- Enabling this option filters chat colors to prevent custom colored messages.
+-- When enabled, '#' in a message is escaped as '##'.
+config.filterChatColors = true
+
 -- Which clientside script records should be blanked out so they are not run
 -- Note: By default, the original character generation scripts are included
 --       because they're not suitable for multiplayer

--- a/scripts/eventHandler.lua
+++ b/scripts/eventHandler.lua
@@ -826,6 +826,10 @@ eventHandler.OnPlayerSendMessage = function(pid, message)
     if Players[pid] ~= nil and Players[pid]:IsLoggedIn() then
         dreamweave.LogMessage(enumerations.log.INFO, logicHandler.GetChatName(pid) .. ": " .. message)
 
+        if config.filterChatColors then 
+            message = message:gsub("#", "##")
+        end
+
         local eventStatus = customEventHooks.triggerValidators("OnPlayerSendMessage", {pid, message})
             
         if eventStatus.validDefaultHandler then


### PR DESCRIPTION
This PR supports the following change: https://github.com/DreamWeave-MP/Dreamweave/pull/69.

This PR by default escapes the hashtag, preventing people to do their own colored messages via a config option, that's enabled by default,

---
With this setting enabled.
![image](https://github.com/DreamWeave-MP/CoreScripts/assets/17028801/799e207b-d075-4027-91a3-e4e1f90bd955)

With the setting disabled.
![image](https://github.com/DreamWeave-MP/CoreScripts/assets/17028801/64bf749a-6ef1-4b6e-98ae-c92de777def6)
