### PR TITLE
feat(tableHelper): add getEntryKeyByValue

### DIFF
--- a/lib/lua/tableHelper.lua
+++ b/lib/lua/tableHelper.lua
@@ -400,6 +400,21 @@ function tableHelper.isEmpty(inputTable)
     return false
 end
 
+--- Retrieve a key associated with a specific value within a table.
+---
+--- @param inputTable table  The table to search within.
+--- @param searchValue any  The value to search for within the table.
+--- @return any|false  The key associated with the searchValue if found, or false if not found.
+--- Note: This function is intended to handle situations where the loaded key may not align with the expected key due to the behavior of "cjson."
+function tableHelper.getEntryKeyByValue(inputTable, searchValue)
+    for key, value in pairs(inputTable) do
+        if key == searchValue or tostring(key) == tostring(searchValue) then
+            return key
+        end
+    end
+    return false
+end
+
 -- Check whether the table is an array with only consecutive numerical keys,
 -- i.e. without any gaps between keys
 -- Based on http://stackoverflow.com/a/6080274

--- a/lib/lua/tableHelper.lua
+++ b/lib/lua/tableHelper.lua
@@ -403,8 +403,8 @@ end
 --- Retrieve a key associated with a specific value within a table.
 ---
 --- @param inputTable table  The table to search within.
---- @param searchValue any  The value to search for within the table.
---- @return any|false  The key associated with the searchValue if found, or false if not found.
+--- @param searchValue string|number  The value to search for within the table.
+--- @return string|number|false  The key associated with the searchValue if found, or false if not found.
 --- Note: This function is intended to handle situations where the loaded key may not align with the expected key due to the behavior of "cjson."
 function tableHelper.getEntryKeyByValue(inputTable, searchValue)
     for key, value in pairs(inputTable) do


### PR DESCRIPTION
This is a kinda lazy way but only working way I found of handling #42, I initially tried to make it return the table to be modified, but it does not seem to work. So the closest i got was returning a matching key on match, and using that for the table.

Example of how i'm using it below.
```lua

local playerVoidStorageName = tableHelper.getEntryKeyByValue(WorldInstance.data.voidStorage, playerName)
if not playerVoidStorageName then
	WorldInstance.data.voidStorage[playerName] = { storageId = "", hasAccess = {} }
	playerVoidStorageName = playerName
else

local storageId = WorldInstance.data.voidStorage[playerVoidStorageName].storageId
```
---
Issue #46: Accidently pushed the non-working broken function attempt of returning a table instead of the key, aswell as named the branch the bad function pushed.